### PR TITLE
Correct Rotate `A` register instructions Z flag

### DIFF
--- a/Opcodes.json
+++ b/Opcodes.json
@@ -158,7 +158,7 @@
 			"operands": [],
 			"immediate": true,
 			"flags": {
-				"Z": "0",
+				"Z": "Z",
 				"N": "0",
 				"H": "0",
 				"C": "C"
@@ -331,7 +331,7 @@
 			"operands": [],
 			"immediate": true,
 			"flags": {
-				"Z": "0",
+				"Z": "Z",
 				"N": "0",
 				"H": "0",
 				"C": "C"
@@ -495,7 +495,7 @@
 			"operands": [],
 			"immediate": true,
 			"flags": {
-				"Z": "0",
+				"Z": "Z",
 				"N": "0",
 				"H": "0",
 				"C": "C"
@@ -664,7 +664,7 @@
 			"operands": [],
 			"immediate": true,
 			"flags": {
-				"Z": "0",
+				"Z": "Z",
 				"N": "0",
 				"H": "0",
 				"C": "C"


### PR DESCRIPTION
According to the GameBoy CPU Manual (but this is also verifiable by comparing with the general-register counterparts, e.g. `RLC r`), when performing a rotation (through carry or not) on the `A` register,  the `Z` flag is set according to the result.

Instructions: `RRA`, `RLA`, `RRCA`, `RLCA`.

Closes #13.