### PR TITLE
Make ALU ops consistent (explicit A)

### DIFF
--- a/Opcodes.json
+++ b/Opcodes.json
@@ -3297,6 +3297,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "B",
 					"immediate": true
 				}
@@ -3316,6 +3320,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "C",
 					"immediate": true
@@ -3337,6 +3345,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "D",
 					"immediate": true
 				}
@@ -3356,6 +3368,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "E",
 					"immediate": true
@@ -3377,6 +3393,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "H",
 					"immediate": true
 				}
@@ -3396,6 +3416,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "L",
 					"immediate": true
@@ -3417,6 +3441,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "HL",
 					"immediate": false
 				}
@@ -3430,12 +3458,17 @@
 			}
 		},
 		"0x97": {
+			
 			"mnemonic": "SUB",
 			"bytes": 1,
 			"cycles": [
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "A",
 					"immediate": true
@@ -3649,6 +3682,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "B",
 					"immediate": true
 				}
@@ -3668,6 +3705,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "C",
 					"immediate": true
@@ -3689,6 +3730,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "D",
 					"immediate": true
 				}
@@ -3708,6 +3753,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "E",
 					"immediate": true
@@ -3729,6 +3778,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "H",
 					"immediate": true
 				}
@@ -3749,6 +3802,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "L",
 					"immediate": true
 				}
@@ -3768,6 +3825,10 @@
 				8
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "HL",
 					"immediate": false
@@ -3791,6 +3852,10 @@
 				{
 					"name": "A",
 					"immediate": true
+				},
+				{
+					"name": "A",
+					"immediate": true
 				}
 			],
 			"immediate": true,
@@ -3808,6 +3873,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "B",
 					"immediate": true
@@ -3829,6 +3898,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "C",
 					"immediate": true
 				}
@@ -3848,6 +3921,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "D",
 					"immediate": true
@@ -3869,6 +3946,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "E",
 					"immediate": true
 				}
@@ -3888,6 +3969,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "H",
 					"immediate": true
@@ -3909,6 +3994,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "L",
 					"immediate": true
 				}
@@ -3928,6 +4017,10 @@
 				8
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "HL",
 					"immediate": false
@@ -3951,6 +4044,10 @@
 				{
 					"name": "A",
 					"immediate": true
+				},
+				{
+					"name": "A",
+					"immediate": true
 				}
 			],
 			"immediate": true,
@@ -3968,6 +4065,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "B",
 					"immediate": true
@@ -3989,6 +4090,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "C",
 					"immediate": true
 				}
@@ -4008,6 +4113,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "D",
 					"immediate": true
@@ -4029,6 +4138,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "E",
 					"immediate": true
 				}
@@ -4048,6 +4161,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "H",
 					"immediate": true
@@ -4069,6 +4186,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "L",
 					"immediate": true
 				}
@@ -4088,6 +4209,10 @@
 				8
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "HL",
 					"immediate": false
@@ -4111,6 +4236,10 @@
 				{
 					"name": "A",
 					"immediate": true
+				},
+				{
+					"name": "A",
+					"immediate": true
 				}
 			],
 			"immediate": true,
@@ -4128,6 +4257,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "B",
 					"immediate": true
@@ -4149,6 +4282,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "C",
 					"immediate": true
 				}
@@ -4168,6 +4305,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "D",
 					"immediate": true
@@ -4189,6 +4330,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "E",
 					"immediate": true
 				}
@@ -4208,6 +4353,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "H",
 					"immediate": true
@@ -4229,6 +4378,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "L",
 					"immediate": true
 				}
@@ -4249,6 +4402,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "HL",
 					"immediate": false
 				}
@@ -4268,6 +4425,10 @@
 				4
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "A",
 					"immediate": true
@@ -4763,6 +4924,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "d8",
 					"bytes": 1,
 					"immediate": true
@@ -5078,6 +5243,10 @@
 			],
 			"operands": [
 				{
+					"name": "A",
+					"immediate": true
+				},
+				{
 					"name": "d8",
 					"bytes": 1,
 					"immediate": true
@@ -5227,6 +5396,10 @@
 				8
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "d8",
 					"bytes": 1,
@@ -5385,6 +5558,10 @@
 				8
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "d8",
 					"bytes": 1,
@@ -5546,6 +5723,10 @@
 				8
 			],
 			"operands": [
+				{
+					"name": "A",
+					"immediate": true
+				},
 				{
 					"name": "d8",
 					"bytes": 1,

--- a/Opcodes.json
+++ b/Opcodes.json
@@ -4587,7 +4587,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -4756,7 +4756,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -4927,7 +4927,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5086,7 +5086,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5246,7 +5246,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5400,7 +5400,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5562,7 +5562,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5727,7 +5727,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}

--- a/Opcodes.json
+++ b/Opcodes.json
@@ -3458,7 +3458,6 @@
 			}
 		},
 		"0x97": {
-			
 			"mnemonic": "SUB",
 			"bytes": 1,
 			"cycles": [

--- a/_includes/optables/description.html
+++ b/_includes/optables/description.html
@@ -81,10 +81,10 @@
 				<p><kbd>LD A, (HL-)</kbd> has the alternative mnemonic <kbd>LD A, (HLD)</kbd> or <kbd>LDD A, (HL)</kbd></p>
 				<p><kbd>LD (HL-), A</kbd> has the alternative mnemonic <kbd>LD (HLD), A</kbd> or <kbd>LDD (HL), A</kbd></p>
 				<p><kbd>LD HL, SP+r8</kbd> has the alternative mnemonic <kbd>LDHL SP, r8</kbd></p>
-				<p>
-					ALU instructions (<kbd>ADD</kbd>, <kbd>ADC</kbd>, <kbd>SUB</kbd>, <kbd>SBC</kbd>, <kbd>AND</kbd>, <kbd>XOR</kbd>, <kbd>OR</kbd>, and <kbd>CP</kbd>) can be written with the left-hand side <kbd>A</kbd> omitted.
+				<div>
+					ALU instructions (<kbd>ADD</kbd>, <kbd>ADC</kbd>, <kbd>SUB</kbd>, <kbd>SBC</kbd>, <kbd>AND</kbd>, <kbd>XOR</kbd>, <kbd>OR</kbd>, and <kbd>CP</kbd>) can be written with the left-hand side <kbd>A</kbd> omitted.<br/>
 					Thus for example <kbd>ADD A, B</kbd> has the alternative mnemonic <kbd>ADD B</kbd>, and <kbd>CP A, $F</kbd> has the alternative mnemonic <kbd>CP $F</kbd>.
-				</p>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/_includes/optables/description.html
+++ b/_includes/optables/description.html
@@ -80,7 +80,11 @@
 				<p><kbd>LD (HL+), A</kbd> has the alternative mnemonic <kbd>LD (HLI), A</kbd> or <kbd>LDI (HL), A</kbd></p>
 				<p><kbd>LD A, (HL-)</kbd> has the alternative mnemonic <kbd>LD A, (HLD)</kbd> or <kbd>LDD A, (HL)</kbd></p>
 				<p><kbd>LD (HL-), A</kbd> has the alternative mnemonic <kbd>LD (HLD), A</kbd> or <kbd>LDD (HL), A</kbd></p>
-				<kbd>LD HL, SP+r8</kbd> has the alternative mnemonic <kbd>LDHL SP, r8</kbd>
+				<p><kbd>LD HL, SP+r8</kbd> has the alternative mnemonic <kbd>LDHL SP, r8</kbd></p>
+				<p>
+					ALU instructions (<kbd>ADD</kbd>, <kbd>ADC</kbd>, <kbd>SUB</kbd>, <kbd>SBC</kbd>, <kbd>AND</kbd>, <kbd>XOR</kbd>, <kbd>OR</kbd>, and <kbd>CP</kbd>) can be written with the left-hand side <kbd>A</kbd> omitted.
+					Thus for example <kbd>ADD A, B</kbd> has the alternative mnemonic <kbd>ADD B</kbd>, and <kbd>CP A, $F</kbd> has the alternative mnemonic <kbd>CP $F</kbd>.
+				</p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
As per #11 and discussions about this, it has been concluded that even though adding the explicit A parameter reduces the readability of the opcodes in the $80-$BF and o3x6 opcode range, it's for the better to have the parameters consistent, and we'll deal separately with the readability issues (there are other readability issues to solve anyway).

Fixes #11.