### PR TITLE
Rename immediate operands to harmonize with RGBDS usage

### DIFF
--- a/OpcodeDescriptions.json
+++ b/OpcodeDescriptions.json
@@ -5,7 +5,7 @@
 			"desc": "No operation.",
 			"flags": false
 		},
-		"ld_r16_d16": {
+		"ld_r16_n16": {
 			"ops": [ 1, 17, 33, 49 ],
 			"desc": "Load value <kbd>%op2%</kbd> into register <kbd>%op1%</kbd>.",
 			"flags": false

--- a/Opcodes.json
+++ b/Opcodes.json
@@ -27,7 +27,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d16",
+					"name": "n16",
 					"bytes": 2,
 					"immediate": true
 				}
@@ -136,7 +136,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -309,7 +309,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -345,7 +345,7 @@
 			],
 			"operands": [
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -370,7 +370,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d16",
+					"name": "n16",
 					"bytes": 2,
 					"immediate": true
 				}
@@ -479,7 +479,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -515,7 +515,7 @@
 			],
 			"operands": [
 				{
-					"name": "r8",
+					"name": "e8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -648,7 +648,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -689,7 +689,7 @@
 					"immediate": true
 				},
 				{
-					"name": "r8",
+					"name": "e8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -714,7 +714,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d16",
+					"name": "n16",
 					"bytes": 2,
 					"immediate": true
 				}
@@ -824,7 +824,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -865,7 +865,7 @@
 					"immediate": true
 				},
 				{
-					"name": "r8",
+					"name": "e8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -999,7 +999,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -1040,7 +1040,7 @@
 					"immediate": true
 				},
 				{
-					"name": "r8",
+					"name": "e8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -1065,7 +1065,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d16",
+					"name": "n16",
 					"bytes": 2,
 					"immediate": true
 				}
@@ -1175,7 +1175,7 @@
 					"immediate": false
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -1216,7 +1216,7 @@
 					"immediate": true
 				},
 				{
-					"name": "r8",
+					"name": "e8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -1350,7 +1350,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -4427,7 +4427,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -4596,7 +4596,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -4763,7 +4763,7 @@
 			],
 			"operands": [
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -4922,7 +4922,7 @@
 					"immediate": true
 				},
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5078,7 +5078,7 @@
 			],
 			"operands": [
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5123,7 +5123,7 @@
 					"immediate": true
 				},
 				{
-					"name": "r8",
+					"name": "e8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5228,7 +5228,7 @@
 			],
 			"operands": [
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5386,7 +5386,7 @@
 			],
 			"operands": [
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5436,7 +5436,7 @@
 					"immediate": true
 				},
 				{
-					"name": "r8",
+					"name": "e8",
 					"bytes": 1,
 					"immediate": true
 				}
@@ -5547,7 +5547,7 @@
 			],
 			"operands": [
 				{
-					"name": "d8",
+					"name": "n8",
 					"bytes": 1,
 					"immediate": true
 				}

--- a/_includes/optables/description.html
+++ b/_includes/optables/description.html
@@ -62,11 +62,11 @@
 	<div class="col">
 		<div id="datatypes" class="card mb-3{% if page.theme == "dark" %} bg-secondary{% endif %}">
 			<div class="card-body">
-				<p><kbd>d8</kbd> means immediate 8-bit data</p>
-				<p><kbd>d16</kbd> means immediate little-endian 16-bit data</p>
-				<p><kbd>a8</kbd> means 8-bit unsigned data, which is added to $FF00 in certain instructions (replacement for missing IN and OUT instructions)</p>
+				<p><kbd>n8</kbd> means immediate 8-bit data</p>
+				<p><kbd>n16</kbd> means immediate little-endian 16-bit data</p>
+				<p><kbd>a8</kbd> means 8-bit unsigned data, which is added to $FF00 in certain instructions to create a 16-bit address in HRAM (High RAM)</p>
 				<p><kbd>a16</kbd> means little-endian 16-bit address</p>
-				<p><kbd>r8</kbd> means 8-bit signed data</p>
+				<p><kbd>e8</kbd> means 8-bit signed data</p>
 			</div>
 		</div>
 
@@ -80,7 +80,7 @@
 				<p><kbd>LD (HL+), A</kbd> has the alternative mnemonic <kbd>LD (HLI), A</kbd> or <kbd>LDI (HL), A</kbd></p>
 				<p><kbd>LD A, (HL-)</kbd> has the alternative mnemonic <kbd>LD A, (HLD)</kbd> or <kbd>LDD A, (HL)</kbd></p>
 				<p><kbd>LD (HL-), A</kbd> has the alternative mnemonic <kbd>LD (HLD), A</kbd> or <kbd>LDD (HL), A</kbd></p>
-				<kbd>LD HL, SP+r8</kbd> has the alternative mnemonic <kbd>LDHL SP, r8</kbd>
+				<kbd>LD HL, SP+e8</kbd> has the alternative mnemonic <kbd>LDHL SP, e8</kbd>
 			</div>
 		</div>
 	</div>

--- a/_includes/optables/mnemonic.html
+++ b/_includes/optables/mnemonic.html
@@ -1,5 +1,5 @@
 {% if include.id == "0xF8" and include.op.mnemonic == "LD" %}
-	LD HL, SP + r8
+	LD HL, SP + e8
 {% elsif include.op.operands.size == 0 %}
 	{{ include.op.mnemonic }}
 {% elsif include.op.operands.size == 1 %}

--- a/_includes/optables/op-table-cell.html
+++ b/_includes/optables/op-table-cell.html
@@ -20,7 +20,7 @@
 	{% assign is16bit = true %}
 {% elsif op.operands.size > 0 and op.operands[0].name == "a16" and op.operands[0].immediate %}
 	{% assign is16bit = true %}
-{% elsif op.operands.size > 0 and op.operands[0].name == "d16" %}
+{% elsif op.operands.size > 0 and op.operands[0].name == "n16" %}
 	{% assign is16bit = true %}
 {% elsif op.operands.size > 1 and op.operands[1].name == "SP" and op.operands[1].immediate %}
 	{% assign is16bit = true %}
@@ -34,7 +34,7 @@
 	{% assign is16bit = true %}
 {% elsif op.operands.size > 1 and op.operands[1].name == "a16" and op.operands[1].immediate %}
 	{% assign is16bit = true %}
-{% elsif op.operands.size > 1 and op.operands[1].name == "d16" %}
+{% elsif op.operands.size > 1 and op.operands[1].name == "n16" %}
 	{% assign is16bit = true %}
 {% else %}
 	{% assign is16bit = false %}


### PR DESCRIPTION
Based on https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LEGEND

Vaguely related to #1