### PR TITLE
Add link to RGBASM opcode reference

### DIFF
--- a/_includes/opcode-reference.html
+++ b/_includes/opcode-reference.html
@@ -1,0 +1,3 @@
+<li class="nav-item">
+	<a class="nav-link" href="https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/">Opcode reference</a>
+</li>

--- a/_layouts/optable.html
+++ b/_layouts/optable.html
@@ -23,6 +23,7 @@ layout: default
 			{% endif %}
 		</li>
 
+		{% include opcode-reference.html %}
 		{% include awesome.html %}
 	{% endcapture %}
 	{% include nav.html content=nav %}


### PR DESCRIPTION
Nice to have while we're waiting for https://gbdev.io/gb-opcodes/opdescriptions/